### PR TITLE
Bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.13
 
 WORKDIR /
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For the overview process visualizations we map all event nodes to event type nod
     ```
     docker build --progress plain -t stackt .
     docker run --rm -it -v my-path-to\stack-t\:/stackt stackt
-    python3 ../python_code/ocel2_generate_dbt_models.py 
+    python3 ../python_code/import_ocel2_generate_dbt_models.py 
     dbt build
     ```
 
@@ -56,7 +56,7 @@ exit
 Next, start a new neo4j container without overwriting the entrypoint.
 
 ```
-docker run --rm -it -v C:\github_projects\stack-t\neo4j\data:/data -v C:\github_projects\stack-t\neo4j\import:/import -p 7474:7474 -p 7687:7687 --env NEO4J_AUTH=none neo4j
+docker run --rm -it -v my-path-to\stack-t\neo4j\data:/data -v my-path-to\stack-t\neo4j\import:/import -p 7474:7474 -p 7687:7687 --env NEO4J_AUTH=none neo4j
 ```
 
 A GUI to interact with the database can be found at `localhost:7474`.

--- a/docker_setup/python_packages.txt
+++ b/docker_setup/python_packages.txt
@@ -1,6 +1,7 @@
-duckdb==0.10.2
-dbt-core==1.8.0
-dbt-duckdb==1.8.0
-pandas==2.1.4
-openpyxl
-graphviz
+duckdb==1.1.3
+dbt-core==1.9.1
+dbt-duckdb==1.9.1
+PyGithub==2.5.0
+polars==1.18.0
+pyarrow==18.1.0
+pandas==2.2.3

--- a/python_code/export_to_docel.py
+++ b/python_code/export_to_docel.py
@@ -1,5 +1,4 @@
 import duckdb
-import pandas as pd
 
 duck_db = 'dev.duckdb'
 export_folder = '../exports/docel/'


### PR DESCRIPTION
Bumped versions:
	python:3.9 -> 3.13
	duckdb==0.10.2 -> 1.1.3
	dbt-core==1.8.0 -> 1.9.1
	dbt-duckdb==1.8.0 -> 1.9.1
	pandas==2.1.4 -> 2.2.3
	
Removed unused libraries:
	openpyxl
	graphviz
	
Added libraries for extracting github logs
	polars==1.18.0
	pyarrow==18.1.0